### PR TITLE
Update pushbullet.js

### DIFF
--- a/lib/pushbullet.js
+++ b/lib/pushbullet.js
@@ -4,7 +4,7 @@ var fs      = require('fs');
 var request = require('request');
 
 // API routes
-var API_BASE          = 'https://www.pushbullet.com/api';
+var API_BASE          = 'https://api.pushbullet.com/api';
 var DEVICES_END_POINT = API_BASE + '/devices';
 var PUSH_END_POINT    = API_BASE + '/pushes';
 


### PR DESCRIPTION
Incorrect URL gave the error message "API is only accessible over HTTPS.". Updated the API_BASE variable as specified here: https://www.pushbullet.com/api
