### PR TITLE
Use JSON interface to fix empty 'list' push messages

### DIFF
--- a/lib/pushbullet.js
+++ b/lib/pushbullet.js
@@ -127,13 +127,12 @@ PushBullet.prototype.push = function push(bullet, callback) {
 	var payload = {};
 
 	if (bullet.type !== 'file') {
-		payload.form = bullet;
+		payload.json = bullet;
 	}
 
 	var req = request.post(PUSH_END_POINT, payload, function(error, response, body) {
 		self.handleResponse(error, response, body, callback);
 	});
-
 
 	if (bullet.type === 'file') {
 		var form = req.form();
@@ -184,7 +183,7 @@ PushBullet.prototype.handleResponse = function handleResponse(error, response, b
 		return;
 	}
 
-	var json = JSON.parse(body);
+	var json = typeof body === 'string' ? JSON.parse(body) : body;
 
 	if (typeof callback === 'function') {
 		callback(null, json);


### PR DESCRIPTION
In 0.2.0, list pushes showed up with empty bodies as FWIW multiple items aren't formatted properly in the form-encoded body. I modified the lib to send push requests as JSON (as per PushBullet support's suggestion), and now everything works as intended.
