### PR TITLE
Fix documentation for pushbullet.link

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ Push a note to the specified device.
 pusher.note('u1qSJddxeKwOGuGW', 'New Note', 'Note body text', function(error, response) {});
 ```
 
-### PushBullet.link(deviceParams, name, url, callback)
+### PushBullet.link(deviceParams, title, body, url, callback)
 
 Push a link to the specified device.
 
 ```javascript
-pusher.link('u1qSJddxeKwOGuGW', 'GitHub', 'https://github.com/', function(error, response) {});
+pusher.link('u1qSJddxeKwOGuGW', 'GitHub', 'How people build software', 'https://github.com/', function(error, response) {});
 ```
 
 ### PushBullet.file(deviceParams, filePath, message, callback)


### PR DESCRIPTION
Updated the documentation as the link function requires a body argument