### PR TITLE
Add End-to-End encryption support

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,3 +415,31 @@ stream.on('push', function(push) {
 	// push message received
 });
 ```
+
+### PushBullet.enableEncryption(encryptionPassword, userIden)
+
+Enables End-to-End encryption.
+
+```javascript
+pusher.me(function(error, user) {
+	// needed to call me() to gather user iden
+	pusher.enableEncryption('YOUR-END-TO-END-PASSWORD', user.iden);
+
+	var stream = pusher.stream();
+
+	stream.on('message', function(message) {
+		console.log(message); // message is decrypted automatically
+	});
+
+	stream.connect();
+
+	var options = {
+		source_user_iden: 'ujpah72o0',
+		target_device_iden: 'ujpah72o0sjAoRtnM0jc',
+		conversation_iden: '+1 303 555 1212',
+		message: 'Hello!'
+	};
+
+	pusher.sendSMS(options, function(error, response) {}); // options are encrypted automatically
+};
+```

--- a/lib/internal/encryption.js
+++ b/lib/internal/encryption.js
@@ -1,0 +1,93 @@
+var forge = require('node-forge');
+
+/**
+ * Encryption module for the PushBullet API.
+ * 
+ * The encryption key is created from a user-supplied password and passed through PBKDF2.
+ * 
+ * @param {String} encryptionPassword End-to-End encryption password set by the user.
+ * @param {String} userIden           The iden of the user (aquired e.g. by the /me request).
+ */
+function Encryption(encryptionPassword, userIden) {
+    var derivedKeyLength = 32;
+    var iterations = 30000;
+    var pseudorandomFunction = forge.md.sha256.create();
+    var encryptionKey = forge.pkcs5.pbkdf2(encryptionPassword, userIden, iterations, derivedKeyLength, pseudorandomFunction);
+
+    this.encryptionKey = encryptionKey;
+}
+
+module.exports = Encryption;
+
+/**
+ * Decodes a base-64 encoded string.
+ * 
+ * @param {String} input A base-64 encoded message to be decoded.
+ * @returns Decoded string in a binary form.
+ */
+Encryption.prototype.atob = function atob(input) {
+  return new Buffer(input, 'base64').toString('binary');
+};
+
+/**
+ * Encodes a string in base-64.
+ * 
+ * @param {String} input A binary string to be encoded.
+ * @returns Base-64 encoded string.
+ */
+Encryption.prototype.btoa = function btoa(input) {
+  return new Buffer(input, 'binary').toString('base64');
+};
+
+/**
+ * Encrypts a message.
+ * 
+ * @param   {String} message A message to encrypt. 
+ * @returns {String} Encrypted message
+ */
+Encryption.prototype.encrypt = function encrypt(message) {
+    var key = this.encryptionKey;
+
+    var initializationVector = forge.random.getBytes(12);
+    var cipher = forge.cipher.createCipher('AES-GCM', key);
+    cipher.start({ iv: initializationVector });
+    cipher.update(forge.util.createBuffer(forge.util.encodeUtf8(message)));
+    cipher.finish();
+
+    var tag = cipher.mode.tag.getBytes();
+    var encryptedMessage = cipher.output.getBytes();
+
+    var result = this.btoa('1' + tag + initializationVector + encryptedMessage);
+
+    return result;
+};
+
+/**
+ * Decrypts a message.
+ * 
+ * @param  {String} A message to decrypt.
+ * @return {String} Decrypted message.
+ */
+Encryption.prototype.decrypt = function decrypt(message) {
+    var binaryMessage = this.atob(message);
+    var key = this.encryptionKey;
+    var version = binaryMessage.substr(0, 1);
+    var tag = binaryMessage.substr(1, 16);
+    var initializationVector = binaryMessage.substr(17, 12);
+    var encryptedMessage = binaryMessage.substr(29);
+
+    if (version !== '1') {
+        throw 'invalid version';
+    }
+
+    var decipher = forge.cipher.createDecipher('AES-GCM', key);
+    decipher.start({
+        iv: initializationVector,
+        tag: tag
+    });
+    decipher.update(forge.util.createBuffer(encryptedMessage));
+    decipher.finish();
+
+    var result = decipher.output.toString('utf8');
+    return result;
+};

--- a/lib/internal/ephemerals.js
+++ b/lib/internal/ephemerals.js
@@ -63,6 +63,14 @@ PushBullet.prototype.dismissEphemeral = function dismissEphemeral(ephemerealOpti
 PushBullet.prototype.sendEphemeral = function sendEphemeral(ephemerealOptions, callback) {
 	var self = this;
 
+	if(this.encryption) {
+		var encryptedOptions = this.encryption.encrypt(JSON.stringify(ephemerealOptions));
+		ephemerealOptions = {
+			ciphertext: encryptedOptions,
+			encrypted: true
+		};
+	}
+
 	var options = {
 		json: {
 			type: 'push',

--- a/lib/internal/stream.js
+++ b/lib/internal/stream.js
@@ -9,9 +9,10 @@ var STREAM_BASE = 'wss://stream.pushbullet.com/websocket';
 /**
  * Event emitter for the Pushbullet streaming API.
  *
- * @param {String} apiKey PushBullet API key.
+ * @param {String}     apiKey PushBullet API key.
+ * @param {Encryption} encryption Encryption instance. 
  */
-function Stream(apiKey) {
+function Stream(apiKey, encryption) {
 	var self = this;
 
 	self.apiKey = apiKey;
@@ -39,8 +40,14 @@ function Stream(apiKey) {
 		});
 
 		connection.on('message', function(message) {
-			if (message.type === 'utf8') {
+			 if (message.type === 'utf8') {
 				var data = JSON.parse(message.utf8Data);
+
+				if(encryption && data.type === 'push' && data.push.encrypted) {
+					var decipheredMessage = encryption.decrypt(data.push.ciphertext);
+					data.push = JSON.parse(decipheredMessage);
+				}
+
 				self.emit('message', data);
 
 				if (data.type === 'nop') {

--- a/lib/pushbullet.js
+++ b/lib/pushbullet.js
@@ -1,8 +1,10 @@
 /*global module,require*/
 
+var forge   = require('node-forge');
 var http    = require('http');
 var request = require('request');
 
+var Encryption = require('./internal/encryption');
 var Stream = require('./internal/stream');
 
 /**
@@ -38,12 +40,22 @@ PushBullet.EPHEMERALS_END_POINT = PushBullet.API_BASE + '/ephemerals';
 module.exports = PushBullet;
 
 /**
+ * Enables End-to-End encryption.
+ * 
+ * @param {String} encryptionPassword End-to-End encryption password set by the user.
+ * @param {String} userIden           The iden of the user (aquired e.g. by the /me request).
+ */
+PushBullet.prototype.enableEncryption = function enableEncryption(encryptionPassword, userIden) {
+	this.encryption = new Encryption(encryptionPassword, userIden);
+};
+
+/**
  * Return a new stream listener.
  *
  * @return {Stream} Stream listener.
  */
 PushBullet.prototype.stream = function stream() {
-	return new Stream(this.apiKey);
+	return new Stream(this.apiKey, this.encryption);
 };
 
 /**
@@ -57,7 +69,7 @@ PushBullet.prototype.stream = function stream() {
  */
 PushBullet.prototype.getList = function getList(endPoint, options, callback) {
 	var self = this;
-
+ 
 	if ( ! callback) {
 		callback = options;
 		options = {};

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "clone": "^2.1.0",
     "mime": "^1.3.4",
+    "node-forge": "^0.7.1",
     "request": "^2.79.0",
     "websocket": "^1.0.24"
   }


### PR DESCRIPTION
This PR adds End-to-End encryption support.

Unfortunately I was able to test it only with SMS messages, since I don't have the Pro subscription enabled. However, the universal copy-paste and mirroring notifications should work just fine since they all share the ephemerals interface. :) 