### PR TITLE
File uploader was not handling stream object properly alexwhitman/nod…

### DIFF
--- a/lib/internal/pushes.js
+++ b/lib/internal/pushes.js
@@ -1,4 +1,4 @@
-import fetch, { FormData } from 'node-fetch';
+import fetch, { FormData, File } from 'node-fetch';
 import fs                  from 'fs';
 import mime                from 'mime';
 import path                from 'path';
@@ -67,7 +67,9 @@ PushBullet.prototype.file = async function file(deviceParams, filePath, body) {
 	const uploadRequestResponseJson = await uploadRequestResponse.json();
 
 	const formData = new FormData();
-	formData.append('file', fs.createReadStream(filePath));
+	const binary = fs.readFileSync(filePath);
+	const file_obj = new File([binary], fileName, { type: fileType });
+	formData.append('file', file_obj);
 
 	const uploadFileResponse = await fetch(uploadRequestResponseJson.upload_url, {
 		method : 'post',


### PR DESCRIPTION
In [pushes.js#70](https://github.com/alexwhitman/node-pushbullet-api/blob/master/lib/internal/pushes.js#L70C2-L70C57) you have:
```
formData.append('file', fs.createReadStream(filePath));
```
I think something has changed here. `formData.append(name, x)` expects a string here so `fs.createReadStream(filePath)` is `toString()`'ed to "[object Object]" and that is what the body of the request is.

There are some differences between native `FormData` and `node-fetch `FormData` and I think there might be some confusion here.

I have removed the streaming component part and replaced it with what was on the node-fetch website for handling file uploads using the `File` object. Now it works and I can see my pictures in the app.

When I was trying to get it to work last time there was also an issue with the file path not being found. I think that was something to do with streams not really knowing where they are from. Anyway, it only worked before if I didn't add a path to the file e.g. '1-jack.jpg' worked but '/path/to/1-jack.jpg' did not work. That appears to be fixed too (with this implementation).

Related to #49 